### PR TITLE
Use tag version for PicoUrl Maven Central publish

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,11 +24,8 @@ jobs:
           java-version: '17'
           cache: gradle
 
-      - name: Set version
-        run: sed -i "s/VERSION_NAME=2.0.1/VERSION_NAME=$GITHUB_REF_NAME/" gradle.properties
-
       - name: Release to Maven Central
-        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
+        run: ./gradlew publishAndReleaseToMavenCentral -PVERSION_NAME="${GITHUB_REF_NAME}" --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}


### PR DESCRIPTION
## Summary
- remove file mutation in publish workflow
- pass tag version to Gradle directly:
  - `-PVERSION_NAME="${GITHUB_REF_NAME}"`

This ensures the pushed git tag is the exact version published to Maven Central.

## Validation
- `./gradlew build`
